### PR TITLE
Added Factory Callback Support

### DIFF
--- a/app/models/image_management/target_image.rb
+++ b/app/models/image_management/target_image.rb
@@ -3,7 +3,7 @@ module ImageManagement
     belongs_to :image_version
     has_many :provider_images
 
-    before_create :create_factory_target_image
+    after_create :create_factory_target_image
 
     attr_accessible :target, :image_version_id
 
@@ -16,20 +16,28 @@ module ImageManagement
     private
     def create_factory_target_image
       begin
-        target_image = ImageFactory::TargetImage.create(:template => template.xml,
-                                                        :target => target)
+        target_image = ImageFactory::TargetImage.new(:template => template.xml,
+                                                        :target => target,
+                                                        :parameters => nil)
+                                                        # A bug in ARes adds parameters twice to the resulting json
+                                                        # when a map is provided in mass assign
+        target_image.parameters =  { :callbacks => ["#{ImageFactory::TargetImage.callback_url}/#{self.id}"] }
+        target_image.save!
+
         populate_factory_fields(target_image)
+        self.save
       rescue => e
         # TODO Add proper error handling
         raise e
       end
     end
-  
+
     def populate_factory_fields(factory_target_image)
       self.status = factory_target_image.status
       self.factory_id = factory_target_image.id
       self.status_detail = factory_target_image.status_detail.activity
       self.progress = factory_target_image.percent_complete
     end
+
   end
 end

--- a/lib/generators/image_management/templates/intializers/image_management_engine.rb
+++ b/lib/generators/image_management/templates/intializers/image_management_engine.rb
@@ -2,3 +2,7 @@
 
 # Image Factory URL
 ImageManagement::ImageFactory::Base.site = "http://localhost:8075/imagefactory"
+
+# TODO We should be able to infer these from Routes
+ImageManagement::ImageFactory::TargetImage.callback_url = "http://localhost:3000/target_images/"
+ImageManagement::ImageFactory::ProviderImage.callback_url = "http://localhost:3000/provider_images/"

--- a/lib/image_factory/model/base.rb
+++ b/lib/image_factory/model/base.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 module ImageManagement
   module ImageFactory
     class Base < ActiveResource::Base
@@ -6,6 +8,15 @@ module ImageManagement
       self.ssl_options = {:verify_mode  => OpenSSL::SSL::VERIFY_NONE}
 
       class << self
+        # Add Callback URL for listening to callback requests
+        def callback_url=(url)
+          @callback_url = URI.parse(url)
+        end
+
+        def callback_url
+          @callback_url
+        end
+
         ## Remove format from the url for resources
         def element_path(id, prefix_options = {}, query_options = nil)
           prefix_options, query_options = split_options(prefix_options) if query_options.nil?

--- a/spec/controllers/provider_images_controller_spec.rb
+++ b/spec/controllers/provider_images_controller_spec.rb
@@ -114,7 +114,7 @@ module ImageManagement
             body = Hash.from_xml(response.body)
             body.keys.should  == ["provider_image"]
 
-            ProviderImage.find(provider_image.id).target_image .should == provider_image.target_image 
+            ProviderImage.find(provider_image.id).target_image.should == provider_image.target_image 
           end
         end
 
@@ -132,6 +132,24 @@ module ImageManagement
         end
       end
 
+      describe "Update Target Image via factory callback" do
+        before(:each) do
+          send_and_accept_json
+        end
+
+        it "should update provider image status attributes via json" do
+          provider_image = Factory(:provider_image_with_full_tree)
+          factory_attributes = {:percent_complete => "100", "status_detail" => {:activity => "Building Image"} }
+          hash = provider_image.attributes.merge(factory_attributes)
+          post :update, :id => provider_image.id, :provider_image => hash
+          response.code.should == "200"
+
+          body = JSON.parse(response.body)
+          body.keys.should  == ["provider_image"]
+          body["provider_image"]["status_detail"].should == "Building Image"
+          body["provider_image"]["progress"].should == "100"
+        end
+      end
     end
   end
 end

--- a/spec/controllers/target_images_controller_spec.rb
+++ b/spec/controllers/target_images_controller_spec.rb
@@ -129,6 +129,24 @@ module ImageManagement
         end
       end
 
+      describe "Update Target Image via factory callback" do
+        before(:each) do
+          send_and_accept_json
+        end
+
+        it "should update target image status attributes via json" do
+          target_image = Factory(:target_image_with_full_tree)
+          factory_attributes = {:percent_complete => "100", :status_detail => {:activity => "Building Image"} }
+          hash = target_image.attributes.merge(factory_attributes)
+          post :update, :id => target_image.id, :target_image => hash
+          response.code.should == "200"
+
+          body = JSON.parse(response.body)
+          body.keys.should  == ["target_image"]
+          body["target_image"]["status_detail"].should == "Building Image"
+          body["target_image"]["progress"].should == "100"
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,10 @@ module RequestContentTypeHelper
     @request.env["CONTENT_TYPE"] = "application/xml"
   end
 
+  def send_and_accept_json
+    @request.env["HTTP_ACCEPT"] = "application/json"
+    @request.env["CONTENT_TYPE"] = "application/json"
+  end
 end
 
 include RequestContentTypeHelper

--- a/test/dummy/config/initializers/image_management_engine.rb
+++ b/test/dummy/config/initializers/image_management_engine.rb
@@ -2,3 +2,7 @@
 
 # Image Factory URL
 ImageManagement::ImageFactory::Base.site = "http://localhost:8075/imagefactory"
+
+# TODO We should be able to infer these from Routes
+ImageManagement::ImageFactory::TargetImage.callback_url = "http://localhost:3000/target_images/"
+ImageManagement::ImageFactory::ProviderImage.callback_url = "http://localhost:3000/provider_images/"


### PR DESCRIPTION
Adds in Factory Callback Support:

= Testing Instructions

== Checkout and Build ImageFactory and plugins 

make rpm
cd imagefactory-plugins/; make rpm

Openstack plugin has a dep not in fedora so will break install; just skip it.

yum install ~/rpmbuld/RPMS/imagefactory-\* --skip-broken

== Run factory 

sudo /usr/bin/imagefactoryd --debug --no_ssl --no_oauth --foreground 

== Start up the test/dummy app

cd <rootdir of IME>/test/dummy 
rake db:migrate; rails s

== Run commands from Rails Console

Open up a rails console;

cd <rootdir of IME>/test/dummy 
.rake db:migrate; rails c

You can create images using the commands below.  Check the test/dummy server log when creating Target and Provider Images for PUT requests.  Then check to see if the model was updated properly.

== Commands

template_xml = "<template><name>mock</name><os><name>RHELMock</name><version>1</version><arch>x86_64</arch><install type=\"iso\"><iso>http://mockhost/RHELMock1-x86_64-DVD.iso</iso></install><rootpw>password</rootpw></os><description>Mock Template</description></template>"

template = ImageManagement::Template.create(:xml => template_xml)

base_image = ImageManagement::BaseImage.new
base_image.template = template
base_image.save

image_version = ImageManagement::ImageVersion.new
image_version.base_image = base_image
image_version.save

target_image = ImageManagement::TargetImage.new(:target => "MockSphere")
target_image.image_version = image_version
target_image.save

provider_image = ImageManagement::ProviderImage.new(:provider => "MockSphere", :credentials => "") 
provider_image.target_image = target_image
provider_image.save
