### PR TITLE
Get our ApplicationController to load.

### DIFF
--- a/lib/tim/engine.rb
+++ b/lib/tim/engine.rb
@@ -1,6 +1,9 @@
 module Tim
   class Engine < Rails::Engine
     isolate_namespace Tim
+    config.after_initialize do
+      require "tim/application_controller"
+    end
     config.generators do |g|
       g.test_framework :rspec, :view_specs => false
       g.template_engine :haml


### PR DESCRIPTION
Previously, when mounting the engine in certain host apps (but
strangely, not all), our ApplicationContoller was not getting
initialized, which would cause strange issues when trying to call the
tim api in those cases.  We are supposed to get this for free, and it
always works correctly in newly-generated rails 3.2.8 apps, but older
apps that were upgraded seem to not behave correctly.  This patch
implements a simple initializer suggested on stackoverflow to make
sure the class gets loaded.

http://stackoverflow.com/questions/11449464/rails-3-2-engine-weirdness-with-before-filter

It still seems to me none of this should be necessary, but I suspect it is some setting that older apps have, I just can't seem to find it. Open to other ideas, but this seems at least fairly well contained if we later find a way to ditch it
