### PR TITLE
Import Image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tim (0.0.1)
+    tim (0.1.2)
       haml
       nokogiri
       rails (~> 3.2.8)
@@ -137,7 +137,7 @@ GEM
     sqlite3 (1.3.6)
     thor (0.15.4)
     tilt (1.3.3)
-    treetop (1.4.10)
+    treetop (1.4.11)
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.33)

--- a/README.rdoc
+++ b/README.rdoc
@@ -246,6 +246,31 @@ Response
     </image_versions>
   </base_image>
 
+==== Import Image
+
+  curl -X POST --header "Accept: application/xml" --header "Content-Type: application/xml" --data "
+  <base_image>
+    <name>MyFirstBaseImage</name>
+    <description>This is my very first base image</description>
+    <template href='http://localhost:3000/tim/templates/3' id='3'></template>
+    <import>true</import>
+    <image_versions type='array'>
+      <image_version>
+        <target_images type='array'>
+          <target_image>
+            <target>ec2</target>
+            <provider_images type='array'>
+              <provider_image>
+                <provider>Amazon EC2</provider>
+                <external_image_id>ami-123456</external_image_id>
+              </provider_image>
+            </provider_images>
+          </target_image>
+        </target_images>
+      </image_version>
+    </image_versions>
+  </base_image>
+  " http://localhost:3000/tim/base_images
 
 ==== Show Base Image
 

--- a/app/models/tim/base_image.rb
+++ b/app/models/tim/base_image.rb
@@ -7,7 +7,7 @@ module Tim
     accepts_nested_attributes_for :template
     accepts_nested_attributes_for :image_versions
 
-    attr_accessible :template, :name, :description
+    attr_accessible :template, :name, :description, :import
     attr_accessible :template_attributes
     attr_accessible :image_versions_attributes, :as => :admin
     attr_protected :id

--- a/app/models/tim/target_image.rb
+++ b/app/models/tim/target_image.rb
@@ -14,10 +14,15 @@ module Tim
 
     attr_protected :id
 
-    after_create :create_factory_target_image
+    after_create :create_factory_target_image, :unless => :imported?
+    after_create :create_import, :if => :imported?
 
     def template
       image_version.base_image.template
+    end
+
+    def imported?
+      image_version.base_image.import
     end
 
     private
@@ -46,5 +51,11 @@ module Tim
       self.progress = factory_target_image.percent_complete
     end
 
+    def create_import
+      self.progress = "COMPLETE"
+      self.status = "IMPORTED"
+      self.status_detail = "Imported Image"
+      self.save
+    end
   end
 end

--- a/app/views/tim/base_images/_base_image.xml.haml
+++ b/app/views/tim/base_images/_base_image.xml.haml
@@ -4,6 +4,7 @@
   %description= base_image.description
   - if base_image.template
     = render :partial => 'tim/templates/template_minimal', :locals => {:template => base_image.template}
+  %import= base_image.import
   %image_versions
     - base_image.image_versions.each do |image_version|
       = render :partial => 'tim/image_versions/image_version_minimal', :locals => {:image_version => image_version}

--- a/db/migrate/20121115151914_add_import_to_tim_base_images.rb
+++ b/db/migrate/20121115151914_add_import_to_tim_base_images.rb
@@ -1,0 +1,5 @@
+class AddImportToTimBaseImages < ActiveRecord::Migration
+  def change
+    add_column :tim_base_images, :import, :boolean, :default => false
+  end
+end

--- a/spec/controllers/base_images_controller_spec.rb
+++ b/spec/controllers/base_images_controller_spec.rb
@@ -30,7 +30,7 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["base_image"]
-            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions"]
+            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions", "import"]
             body["base_image"]["template"].keys.should =~ ["id", "href"]
           end
         end
@@ -44,7 +44,7 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["base_image"]
-            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions"]
+            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions", "import"]
             body["base_image"]["template"].keys.should =~ ["id", "href"]
           end
 
@@ -66,7 +66,7 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["base_image"]
-            body["base_image"].keys.should =~ ["id", "href", "name", "description", "image_versions"]
+            body["base_image"].keys.should =~ ["id", "href", "name", "description", "image_versions", "import"]
           end
 
           it "should return an existing base image as XML with template" do
@@ -77,7 +77,7 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["base_image"]
-            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions"]
+            body["base_image"].keys.should =~ ["template", "id", "href", "name", "description", "image_versions", "import"]
             body["base_image"]["template"].keys.should =~ ["id", "href"]
           end
 
@@ -93,7 +93,7 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["base_image"]
-            body["base_image"].keys.should =~ ["image_versions", "template", "id", "href", "name", "description"]
+            body["base_image"].keys.should =~ ["image_versions", "template", "id", "href", "name", "description", "import"]
             body["base_image"]["image_versions"]["image_version"].size.should == 2
           end
         end

--- a/spec/controllers/provider_images_controller_spec.rb
+++ b/spec/controllers/provider_images_controller_spec.rb
@@ -10,6 +10,7 @@ module Tim
         TargetImage.any_instance.stub(:template).and_return(FactoryGirl.build(:template))
         ProviderImage.any_instance.stub(:create_factory_provider_image).and_return(true)
         TargetImage.any_instance.stub(:create_factory_target_image).and_return(true)
+        TargetImage.any_instance.stub(:imported?).and_return(false)
         @status_detail = mock(:status)
         @status_detail.stub(:activity).and_return("Building")
         ImageFactory::TargetImage.stub(:create).and_return(FactoryGirl.build(:image_factory_target_image, :status_detail => @status_detail))

--- a/spec/controllers/target_images_controller_spec.rb
+++ b/spec/controllers/target_images_controller_spec.rb
@@ -9,6 +9,7 @@ module Tim
         send_and_accept_xml
         TargetImage.any_instance.stub(:template).and_return(FactoryGirl.build(:template))
         TargetImage.any_instance.stub(:create_factory_target_image).and_return(true)
+        TargetImage.any_instance.stub(:imported?).and_return(false)
         @status_detail = mock(:status)
         @status_detail.stub(:activity).and_return("Building")
         TargetImagesController.any_instance.stub(:template_exists?).and_return false
@@ -32,8 +33,8 @@ module Tim
             body["target_image"]["image_version"]["id"].should == target_image.image_version.id.to_s
           end
 
-          it "should create a new target image as with existing image version" do
-            image_version = FactoryGirl.create(:image_version)
+          it "should create a new target image for imported images" do
+            image_version = FactoryGirl.create(:image_version_import)
             post :create, { :target_image => {:image_version => {:id => image_version.id}, :target => "mock"}}
             response.code.should == "201"
 

--- a/spec/factories/tim/base_image.rb
+++ b/spec/factories/tim/base_image.rb
@@ -7,4 +7,8 @@ FactoryGirl.define do
   factory :base_image_with_template, :parent => :base_image do
     association :template, :factory => :template
   end
+
+  factory :base_image_import, :parent => :base_image do
+    import true
+  end
 end

--- a/spec/factories/tim/image_version.rb
+++ b/spec/factories/tim/image_version.rb
@@ -16,5 +16,9 @@ module Tim
         FactoryGirl.create_list(:target_image, 2, :image_version => image_version)
       end
     end
+
+    factory :image_version_import, :parent => :image_version do
+      association :base_image, :factory => :base_image_import
+    end
   end
 end

--- a/spec/factories/tim/provider_image.rb
+++ b/spec/factories/tim/provider_image.rb
@@ -6,4 +6,8 @@ FactoryGirl.define do
   factory :provider_image_with_full_tree, :parent => :provider_image do
     association :target_image, :factory => :target_image_with_full_tree
   end
+
+  factory :provider_image_import, :parent => :provider_image do
+    association :target_image, :factory => :target_image_import
+  end
 end

--- a/spec/factories/tim/target_image.rb
+++ b/spec/factories/tim/target_image.rb
@@ -7,4 +7,8 @@ FactoryGirl.define do
   factory :target_image_with_full_tree, :parent => :target_image do
     association :image_version, :factory => :image_version_with_full_tree
   end
+
+  factory :target_image_import, :parent => :target_image do
+    association :image_version, :factory => :image_version_import
+  end
 end

--- a/spec/models/dummy/provider_account_spec.rb
+++ b/spec/models/dummy/provider_account_spec.rb
@@ -4,6 +4,7 @@ describe ProviderAccount do
   describe "Dummy Model relationships" do
     before(:each) do
       Tim::ProviderImage.any_instance.stub(:create_factory_provider_image).and_return(true)
+      Tim::ProviderImage.any_instance.stub(:imported?).and_return(false)
     end
 
     it 'should have many provider images' do

--- a/spec/models/dummy/provider_type_spec.rb
+++ b/spec/models/dummy/provider_type_spec.rb
@@ -4,6 +4,7 @@ describe ProviderType do
   describe "Dummy Model relationships" do
     before (:each) do
       Tim::TargetImage.any_instance.stub(:create_factory_target_image).and_return(true)
+      Tim::TargetImage.any_instance.stub(:imported?).and_return(false)
     end
 
     it 'should have many target images' do

--- a/spec/models/image_version_spec.rb
+++ b/spec/models/image_version_spec.rb
@@ -5,6 +5,7 @@ module Tim
     describe "Model relationships" do
       before (:each) do
         TargetImage.any_instance.stub(:create_factory_target_image).and_return(true)
+        Tim::TargetImage.any_instance.stub(:imported?).and_return(false)
       end
 
       it 'should have one base image' do

--- a/spec/models/provider_image_spec.rb
+++ b/spec/models/provider_image_spec.rb
@@ -4,6 +4,8 @@ module Tim
   describe ProviderImage do
     before (:each) do
       TargetImage.any_instance.stub(:create_factory_target_image).and_return(true)
+      Tim::ProviderImage.any_instance.stub(:imported?).and_return(false)
+      Tim::TargetImage.any_instance.stub(:imported?).and_return(false)
     end
 
     describe "Model relationships" do
@@ -63,6 +65,12 @@ module Tim
           pi.provider_account_id.should == "mock-account-123"
         end
 
+        it "should not make a request to factory if the base image is imported" do
+          Tim::ProviderImage.any_instance.stub(:imported?).and_return(true)
+          ti = FactoryGirl.build(:provider_image_import)
+          ti.should_not_receive(:create_factory_provider_image)
+          ti.save
+        end
       end
     end
   end

--- a/spec/models/target_image_spec.rb
+++ b/spec/models/target_image_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 module Tim
   describe TargetImage do
 
+    before (:each) do
+      Tim::TargetImage.any_instance.stub(:imported?).and_return(false)
+    end
     #TODO FIX: A bug in RSpec V2.1 means that any_instance propogates across context therefore we are  stubbing each 
     #target_image.   This bug is fixed in RSpec V2.6 
     describe "Model relationships" do
@@ -69,6 +72,12 @@ module Tim
           ti.progress.should == "0"
         end
 
+        it "should not make a request to factory if the base image is imported" do
+          Tim::TargetImage.any_instance.stub(:imported?).and_return(true)
+          ti = FactoryGirl.build(:target_image_import)
+          ti.should_not_receive(:create_factory_target_image)
+          ti.save
+        end
       end
     end
   end

--- a/spec/views/provider_images_spec.rb
+++ b/spec/views/provider_images_spec.rb
@@ -7,6 +7,7 @@ module Tim
         .stub(:create_factory_target_image)
       Tim::TargetImage.any_instance.stub(:template)
         .and_return FactoryGirl.build(:template)
+      Tim::TargetImage.any_instance.stub(:imported?).and_return(false)
 
       view.stub(:provider_image).and_return FactoryGirl.build(:provider_image)
       [:provider_image_url, :target_image_url].each do |method|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,14 +13,30 @@
 
 ActiveRecord::Schema.define(:version => 20120423123114264114) do
 
+  create_table "pool_families", :force => true do |t|
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "provider_accounts", :force => true do |t|
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "provider_types", :force => true do |t|
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
   create_table "tim_base_images", :force => true do |t|
     t.string   "name"
     t.string   "description"
     t.integer  "template_id"
     t.integer  "user_id"
-    t.datetime "created_at",     :null => false
-    t.datetime "updated_at",     :null => false
+    t.datetime "created_at",                        :null => false
+    t.datetime "updated_at",                        :null => false
     t.integer  "pool_family_id"
+    t.boolean  "import",         :default => false
   end
 
   create_table "tim_image_versions", :force => true do |t|
@@ -58,21 +74,6 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
 
   create_table "tim_templates", :force => true do |t|
     t.text     "xml"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  create_table "pool_families", :force => true do |t|
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  create_table "provider_accounts", :force => true do |t|
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  create_table "provider_types", :force => true do |t|
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end


### PR DESCRIPTION
Allows Image Importing via API and object model.  To allow imported images, the base_image.import must == true.

This allows the client to set the external_image_id and removes the after_create filters (which would normally kick off a factory build/push).

See the README for an example API request.

https://github.com/aeolus-incubator/tim/issues/42
