### PR TITLE
Catch XML Syntax Error exceptions in Template

### DIFF
--- a/app/validators/template_validator.rb
+++ b/app/validators/template_validator.rb
@@ -4,12 +4,16 @@ class TemplateValidator < ActiveModel::Validator
   @@template_rng = File.join(Tim::Engine.root, "config/schemas", "tdl.rng")
 
   def validate(record)
-    rng = Nokogiri::XML::RelaxNG(File.read(@@template_rng))
-    xml = Nokogiri::XML(record.xml) { |config| config.strict }
+    begin
+      rng = Nokogiri::XML::RelaxNG(File.read(@@template_rng))
+      xml = Nokogiri::XML(record.xml) { |config| config.strict }
 
-    rng.validate(xml).each do |error|
-      record.errors.add :xml, error.message
-    end
+      rng.validate(xml).each do |error|
+        record.errors.add :xml, error.message
+      end
+     rescue Nokogiri::XML::SyntaxError => e
+       record.errors.add :xml, "Syntax error on line #{e.line} at column #{e.column}: #{e.message}"
+     end
   end
 
 end

--- a/spec/validators/template_validator_spec.rb
+++ b/spec/validators/template_validator_spec.rb
@@ -15,5 +15,15 @@ module Tim
       TemplateValidator.new({}).validate(template)
       template.errors.size.should > 0
     end
+
+    it "should add xml syntax errors to template errors" do
+      template = FactoryGirl.build(:template,
+                                   :xml => "<invalid_template>
+                                            </invalid_template")
+      TemplateValidator.new({}).validate(template)
+      template.errors.size.should > 0
+      template.errors.messages.first.to_s
+        .include?("Syntax error on line 2").should == true
+    end
   end
 end


### PR DESCRIPTION
Previously the Template validator raised an XML Syntax exception when the XML was malformed.  This is incorrect behaviour for a Rails validator.  We now catch the exception and add it to template.errors

https://github.com/aeolus-incubator/tim/issues/55
