### PR TITLE
Remove extraneous files from released gem

### DIFF
--- a/tim.gemspec
+++ b/tim.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["{spec,test}/**/*"]
+  s.test_files.reject! { |fn| fn.match(/sqlite|tmp|log/) }
 
   s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "haml"


### PR DESCRIPTION
Not sure if this means we just list all the files that we _do_ want, or what yet, but we want to not have in our gem release:

```
test/dummy/db/development.sqlite3
test/dummy/db/test.sqlite3
test/dummy/log/development.log
test/dummy/log/test.log
test/dummy/tmp/cache/assets/*
```
