### PR TITLE
Add Snapshot capability to Tim

### DIFF
--- a/app/models/tim/provider_image.rb
+++ b/app/models/tim/provider_image.rb
@@ -25,8 +25,7 @@ module Tim
     private
     def create_factory_provider_image
       begin
-        provider_image = ImageFactory::ProviderImage.new(:target_image_id => self.target_image.factory_id,
-                                                         :provider => self.provider,
+        provider_image = ImageFactory::ProviderImage.new(:provider => self.provider,
                                                          :credentials => @credentials,
                                                           # TODO Remove this when upgrading to 3.2
                                                           # target conflicts with rails 3.0.10
@@ -38,6 +37,13 @@ module Tim
         # Setting parameters at mass assign results in json => {"target_image":"parameters":{"parameters":{"..."}}}"
         # This should be tested and removed if fixed in 3.2
         provider_image.parameters = { :callbacks => ["#{ImageFactory::ProviderImage.callback_url}/#{self.id}"] }
+        if target_image.snapshot?
+          provider_image.parameters[:snapshot] = true
+          provider_image.template = self.target_image.template.xml
+        else
+          provider_image.target_image_id = self.target_image.factory_id
+        end
+
         provider_image.save!
         populate_factory_fields(provider_image)
         self.save

--- a/app/models/tim/target_image.rb
+++ b/app/models/tim/target_image.rb
@@ -17,7 +17,7 @@ module Tim
 
     attr_protected :id
 
-    after_create :create_factory_target_image, :unless => :imported?
+    after_create :create_factory_target_image, :if => :create_factory_target_image?
     after_create :create_import, :if => :imported?
 
     def template
@@ -26,6 +26,10 @@ module Tim
 
     def imported?
       image_version.base_image.import
+    end
+
+    def snapshot?
+      build_method == "SNAPSHOT"
     end
 
     private
@@ -59,6 +63,11 @@ module Tim
       self.status = "IMPORTED"
       self.status_detail = "Imported Image"
       self.save
+    end
+
+    private 
+    def create_factory_target_image?
+      !imported? && !snapshot?
     end
   end
 end

--- a/app/views/tim/target_images/_target_image.xml.haml
+++ b/app/views/tim/target_images/_target_image.xml.haml
@@ -1,6 +1,7 @@
 !!! XML
 %target_image{:id => target_image.id, :href => target_image_url(target_image.id) }
   %target= target_image.target
+  %build_method= target_image.build_method
   %status= target_image.status
   %status_detail= target_image.status_detail
   %progress= target_image.progress

--- a/db/migrate/20121210131423_add_build_method_to_target_image.rb
+++ b/db/migrate/20121210131423_add_build_method_to_target_image.rb
@@ -1,0 +1,5 @@
+class AddBuildMethodToTargetImage < ActiveRecord::Migration
+  def change
+    add_column :tim_target_images, :build_method, :string, :default => "BARE_METAL"
+  end
+end

--- a/spec/controllers/target_images_controller_spec.rb
+++ b/spec/controllers/target_images_controller_spec.rb
@@ -29,7 +29,8 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["target_image"]
-            body["target_image"].keys.should  =~ ["target", "status", "status_detail", "progress", "href", "id", "provider_images", "image_version"]
+            body["target_image"].keys.should  =~ ["target", "status", "status_detail", "progress", "href", "id",
+                                                  "provider_images", "image_version", "build_method"]
             body["target_image"]["image_version"]["id"].should == target_image.image_version.id.to_s
           end
 
@@ -40,7 +41,8 @@ module Tim
 
             body = Hash.from_xml(response.body)
             body.keys.should  == ["target_image"]
-            body["target_image"].keys.should  =~ ["target", "status", "status_detail", "progress", "href", "id", "provider_images", "image_version"]
+            body["target_image"].keys.should  =~ ["target", "status", "status_detail", "progress", "href", "id",
+                                                  "provider_images", "image_version", "build_method"]
             body["target_image"]["image_version"]["id"].should == image_version.id.to_s
           end
         end
@@ -64,7 +66,7 @@ module Tim
             body = Hash.from_xml(response.body)
             body.keys.should  == ["target_image"]
             body["target_image"].keys.should =~ ["id", "href", "image_version", 
-              "provider_images", "target", "status", "status_detail", "progress"]
+              "provider_images", "target", "status", "status_detail", "progress", "build_method"]
           end
         end
 

--- a/spec/factories/tim/target_image.rb
+++ b/spec/factories/tim/target_image.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :target_image, :class => Tim::TargetImage do
     target 'Mock'
+    build_method 'BARE_METAL'
   end
 
   factory :target_image_with_full_tree, :parent => :target_image do

--- a/spec/models/provider_image_spec.rb
+++ b/spec/models/provider_image_spec.rb
@@ -71,6 +71,12 @@ module Tim
           ti.should_not_receive(:create_factory_provider_image)
           ti.save
         end
+
+        it "should make a request to factory if the target image build type is SNAPSHOT" do
+          ti = FactoryGirl.build(:provider_image)
+          ti.should_not_receive(:create_factory_provider_image)
+          ti.save
+        end
       end
     end
   end

--- a/spec/models/target_image_spec.rb
+++ b/spec/models/target_image_spec.rb
@@ -78,6 +78,12 @@ module Tim
           ti.should_not_receive(:create_factory_target_image)
           ti.save
         end
+
+        it "should not make a request to factory if the target image is build method is SNAPSHOT" do
+          ti = FactoryGirl.build(:target_image_import, :build_method => "SNAPSHOT")
+          ti.should_not_receive(:create_factory_target_image)
+          ti.save
+        end
       end
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -67,9 +67,10 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
     t.string   "status"
     t.string   "status_detail"
     t.string   "progress"
-    t.datetime "created_at",       :null => false
-    t.datetime "updated_at",       :null => false
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
     t.integer  "provider_type_id"
+    t.string   "build_method",     :default => "BARE_METAL"
   end
 
   create_table "tim_templates", :force => true do |t|


### PR DESCRIPTION
You can test this manually in the console using the commands below.  Be sure to have imagefactory running:

== Commands

```
template_xml = "<template><name>mock</name><os><name>RHELMock</name><version>1</version><arch>x86_64</arch><install type=\"iso\"><iso>http://mockhost/RHELMock1-x86_64-DVD.iso</iso></install><rootpw>password</rootpw></os><description>Mock Template</description></template>"

template = Tim::Template.create(:xml => template_xml)

base_image = Tim::BaseImage.new(:name => "BaseImage")
base_image.template = template
base_image.save

image_version = Tim::ImageVersion.new
image_version.base_image = base_image
image_version.save

target_image = Tim::TargetImage.new(:target => "MockSphere", :build_method => "SNAPSHOT")
target_image.image_version = image_version
target_image.save

provider_image = Tim::ProviderImage.new(:provider => "MockSphere", :credentials => "mock_credentials")
provider_image.target_image = target_image
provider_image.save
```
