### PR TITLE
Load Rails Patch

### DIFF
--- a/lib/tim/engine.rb
+++ b/lib/tim/engine.rb
@@ -11,6 +11,11 @@ module Tim
       Dir[Rails.root.join('app', 'decorators', '**', '*_decorator.rb')].each do |d|
         require d
       end
+
+      # Load everything under patches dir
+      Dir[Tim::Engine.root.join('app', 'patches', '**', '*.rb')].each do |p|
+        require p
+      end
     end
   end
 end


### PR DESCRIPTION
Loads all patches included in the app/patches directory in Tim for environments where lazy loading is switched on.
