### PR TITLE
Removed protect_from_forgery before_filter

### DIFF
--- a/app/controllers/tim/application_controller.rb
+++ b/app/controllers/tim/application_controller.rb
@@ -1,7 +1,5 @@
 module Tim
   class ApplicationController < ::ApplicationController
-    protect_from_forgery
-
     respond_to :html, :xml
 
     append_before_filter :set_default_respond_options


### PR DESCRIPTION
I think it's OK to leave responsibility/decision if this filter should be
used or not on application which includes Tim engine. protect_from_forgery
filter is usually set for all application controllers
(in ApplicationController). Adding this filter again in Tim's controller
implies that this filter is called twice during executing filter chain.

This filter resets session, impact for Conductor is that then for
requests which uses http auth basic is session not set.
