### PR TITLE
Renamed factory provider account id

### DIFF
--- a/app/models/tim/provider_image.rb
+++ b/app/models/tim/provider_image.rb
@@ -60,7 +60,7 @@ module Tim
       self.progress = factory_provider_image.percent_complete
       self.provider = factory_provider_image.provider
       self.external_image_id = factory_provider_image.identifier_on_provider
-      self.provider_account_id = factory_provider_image.provider_account_identifier
+      self.factory_provider_account_id = factory_provider_image.provider_account_identifier
     end
 
     # TODO At the moment this method simply sets fields to import defaults.

--- a/db/migrate/20121216131814_rename_provider_account_id_attribute.rb
+++ b/db/migrate/20121216131814_rename_provider_account_id_attribute.rb
@@ -1,0 +1,13 @@
+class RenameProviderAccountIdAttribute < ActiveRecord::Migration
+  def up
+    change_table :tim_provider_images do |t|
+      t.rename :provider_account_id, :factory_provider_account_id
+    end
+  end
+
+  def down
+    change_table :tim_provider_images do |t|
+      t.rename :factory_provider_account_id, :provider_account_id
+    end
+  end
+end

--- a/spec/models/provider_image_spec.rb
+++ b/spec/models/provider_image_spec.rb
@@ -62,7 +62,7 @@ module Tim
           pi.progress.should == "10"
           pi.provider.should == "MockSphere"
           pi.external_image_id.should == "mock-123456"
-          pi.provider_account_id.should == "mock-account-123"
+          pi.factory_provider_account_id.should == "mock-account-123"
         end
 
         it "should not make a request to factory if the base image is imported" do

--- a/test/dummy/db/migrate/20121216133232_add_provider_account_id_to_provider_images.rb
+++ b/test/dummy/db/migrate/20121216133232_add_provider_account_id_to_provider_images.rb
@@ -1,0 +1,5 @@
+class AddProviderAccountIdToProviderImages < ActiveRecord::Migration
+  def change
+    add_column :tim_provider_images, :provider_account_id, :integer
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -51,13 +51,14 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
     t.integer  "target_image_id"
     t.string   "provider"
     t.string   "external_image_id"
-    t.string   "provider_account_id"
+    t.string   "factory_provider_account_id"
     t.boolean  "snapshot"
     t.string   "status"
     t.string   "status_detail"
     t.string   "progress"
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
+    t.integer  "provider_account_id"
   end
 
   create_table "tim_target_images", :force => true do |t|


### PR DESCRIPTION
Resolves: https://github.com/aeolus-incubator/tim/issues/81

Renames TIm::ProviderImage.provider_account_id to factory_provider_account_id

N.B.  You must run migrations for this change to take place.
