### PR TITLE
Enforce equivilence for Target Images with same Image Version

### DIFF
--- a/db/migrate/20121216134538_add_factory_base_image_id_to_image_versions.rb
+++ b/db/migrate/20121216134538_add_factory_base_image_id_to_image_versions.rb
@@ -1,0 +1,5 @@
+class AddFactoryBaseImageIdToImageVersions < ActiveRecord::Migration
+  def change
+    add_column :tim_image_versions, :factory_base_image_id, :string
+  end
+end

--- a/lib/image_factory/model/base_image.rb
+++ b/lib/image_factory/model/base_image.rb
@@ -1,0 +1,6 @@
+module Tim
+  module ImageFactory
+    class BaseImage < Base
+    end
+  end
+end

--- a/spec/factories/tim/image_factory/target_image.rb
+++ b/spec/factories/tim/image_factory/target_image.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     status "NEW"
     id '4cc3b024-5fe7-4b0b-934b-c5d463b990b0'
     percent_complete '0'
+    base_image_id '2cc3b024-5fe7-4b0b-934b-c5d463b990b0'
   end
 end

--- a/spec/models/target_image_spec.rb
+++ b/spec/models/target_image_spec.rb
@@ -70,6 +70,7 @@ module Tim
           ti.status.should == "NEW"
           ti.status_detail.should == "Building"
           ti.progress.should == "0"
+          ti.image_version.factory_base_image_id.should == '2cc3b024-5fe7-4b0b-934b-c5d463b990b0'
         end
 
         it "should not make a request to factory if the base image is imported" do
@@ -83,6 +84,33 @@ module Tim
           ti = FactoryGirl.build(:target_image_import, :build_method => "SNAPSHOT")
           ti.should_not_receive(:create_factory_target_image)
           ti.save
+        end
+
+        it "should send base image id to factory if it is set on image version" do
+          image_version = FactoryGirl.build(:image_version_with_full_tree,
+                                            :factory_base_image_id => "1234")
+          target_image = FactoryGirl.build(:target_image,
+                                           :image_version => image_version)
+          target_image.stub(:populate_factory_fields)
+          mock_target_image = double("factory_target_image")
+          Tim::ImageFactory::TargetImage.stub(:new).and_return(mock_target_image)
+          mock_target_image.should_receive(:parameters=)
+          mock_target_image.should_receive(:base_image_id=)
+          mock_target_image.should_receive(:save!)
+          target_image.save
+        end
+
+        it "should send template to factory if factory base image id is not set on image version" do
+          image_version = FactoryGirl.build(:image_version_with_full_tree)
+          target_image = FactoryGirl.build(:target_image,
+                                           :image_version => image_version)
+          target_image.stub(:populate_factory_fields)
+          mock_target_image = double("factory_target_image")
+          Tim::ImageFactory::TargetImage.stub(:new).and_return(mock_target_image)
+          mock_target_image.should_receive(:parameters=)
+          mock_target_image.should_receive(:template=)
+          mock_target_image.should_receive(:save!)
+          target_image.save
         end
       end
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -42,8 +42,9 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
   create_table "tim_image_versions", :force => true do |t|
     t.integer  "base_image_id"
     t.integer  "template_id"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at",            :null => false
+    t.datetime "updated_at",            :null => false
+    t.string   "factory_base_image_id"
   end
 
   create_table "tim_provider_images", :force => true do |t|


### PR DESCRIPTION
When creating a second target image for the same image
version.  We should pass in the factory base image id
to be sure that factory uses the already built base image
rather than creating a new one from the template.

This ensures that we have equivilence of Target Images
across ImageVersions.

To see this working in factory.

1) Set up factory + tim
2) Open Console and Create 2 target images with the same image version

```
template_xml = "<template><name>mock</name><os><name>RHELMock</name><version>1</version><arch>x86_64</arch><install type=\"iso\"><iso>http://mockhost/RHELMock1-x86_64-DVD.iso</iso></install><rootpw>password</rootpw></os><description>Mock Template</description></template>"

template = Tim::Template.create(:xml => template_xml)

base_image = Tim::BaseImage.new(:name => "BaseImage")
base_image.template = template
base_image.save

image_version = Tim::ImageVersion.new
image_version.base_image = base_image
image_version.save

target_image1 = Tim::TargetImage.new(:target => "MockSphere")
target_image1.image_version = image_version
target_image1.save

target_image2 = Tim::TargetImage.new(:target => "MockSphere")
target_image2.image_version = image_version
target_image2.save

### Take note of the factory ids ###
# Factory Base Image ID
target_image1.image_version.factory_base_image_id

# Factory Target Image IDs
target_image1.factory_id
target_image2.factory_id

```

Inspect the Target Images response from factory.  Look for the Base Image IDs

```
 curl http://localhost:8075/imagefactory/target_images/<target_image1_factory_id>
 curl http://localhost:8075/imagefactory/target_images/<target_image2_factory_id>
```

Both target images base image id (from factory) should match the output of:

```
target_image1.image_version.factory_base_image_id
```
