### PR TITLE
Fix connection error

### DIFF
--- a/app/exceptions/tim/exceptions.rb
+++ b/app/exceptions/tim/exceptions.rb
@@ -1,0 +1,6 @@
+module Tim
+  module Error
+    class ImagefactoryConnectionRefused < ::StandardError
+    end
+  end
+end

--- a/app/models/tim/provider_image.rb
+++ b/app/models/tim/provider_image.rb
@@ -47,6 +47,9 @@ module Tim
         provider_image.save!
         populate_factory_fields(provider_image)
         self.save
+      rescue Errno::ECONNREFUSED
+        raise Tim::Error::ImagefactoryConnectionRefused.new("Unable to connect"\
+         " to Imagefactory server @ #{Tim::ImageFactory::Base.site}")
       rescue => e
         # TODO Add proper error handling
         raise e

--- a/app/models/tim/target_image.rb
+++ b/app/models/tim/target_image.rb
@@ -50,6 +50,9 @@ module Tim
 
         populate_factory_fields(target_image)
         self.save
+      rescue Errno::ECONNREFUSED
+        raise Tim::Error::ImagefactoryConnectionRefused.new("Unable to connect"\
+         " to Imagefactory server @ #{Tim::ImageFactory::Base.site}")
       rescue => e
         # TODO Add proper error handling
         raise e

--- a/db/migrate/20121216134538_add_factory_base_image_id_to_image_versions.rb
+++ b/db/migrate/20121216134538_add_factory_base_image_id_to_image_versions.rb
@@ -1,0 +1,5 @@
+class AddFactoryBaseImageIdToImageVersions < ActiveRecord::Migration
+  def change
+    add_column :tim_image_versions, :factory_base_image_id, :string
+  end
+end

--- a/lib/image_factory/model/base_image.rb
+++ b/lib/image_factory/model/base_image.rb
@@ -1,0 +1,6 @@
+module Tim
+  module ImageFactory
+    class BaseImage < Base
+    end
+  end
+end

--- a/lib/tim/engine.rb
+++ b/lib/tim/engine.rb
@@ -16,6 +16,11 @@ module Tim
       Dir[Tim::Engine.root.join('app', 'patches', '**', '*.rb')].each do |p|
         require p
       end
+
+      # Load Exceptions
+      Dir[Tim::Engine.root.join('app', 'exceptions', '**', '*.rb')].each do |e|
+        require e
+      end
     end
   end
 end

--- a/spec/factories/tim/image_factory/target_image.rb
+++ b/spec/factories/tim/image_factory/target_image.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     status "NEW"
     id '4cc3b024-5fe7-4b0b-934b-c5d463b990b0'
     percent_complete '0'
+    base_image_id '2cc3b024-5fe7-4b0b-934b-c5d463b990b0'
   end
 end

--- a/spec/models/provider_image_spec.rb
+++ b/spec/models/provider_image_spec.rb
@@ -77,6 +77,15 @@ module Tim
           ti.should_not_receive(:create_factory_provider_image)
           ti.save
         end
+
+        it "should raise ImagefactoryConnectionRefused exception when it can"\
+          " not connect to Imagefactory" do
+          expect {
+            Tim::ImageFactory::ProviderImage.stub(:new).and_raise(Errno::ECONNREFUSED)
+            provider_image = FactoryGirl.build(:provider_image_with_full_tree)
+            provider_image.send(:create_factory_provider_image)
+          }.to raise_error(Tim::Error::ImagefactoryConnectionRefused)
+        end
       end
     end
   end

--- a/spec/models/target_image_spec.rb
+++ b/spec/models/target_image_spec.rb
@@ -112,6 +112,15 @@ module Tim
           mock_target_image.should_receive(:save!)
           target_image.save
         end
+
+        it "should raise ImagefactoryConnectionRefused exception when it can"\
+          " not connect to Imagefactory" do
+          expect {
+            Tim::ImageFactory::TargetImage.stub(:new).and_raise(Errno::ECONNREFUSED)
+            target_image = TargetImage.new
+            target_image.send(:create_factory_target_image)
+          }.to raise_error(Tim::Error::ImagefactoryConnectionRefused)
+        end
       end
     end
   end

--- a/spec/models/target_image_spec.rb
+++ b/spec/models/target_image_spec.rb
@@ -70,6 +70,7 @@ module Tim
           ti.status.should == "NEW"
           ti.status_detail.should == "Building"
           ti.progress.should == "0"
+          ti.image_version.factory_base_image_id.should == '2cc3b024-5fe7-4b0b-934b-c5d463b990b0'
         end
 
         it "should not make a request to factory if the base image is imported" do
@@ -83,6 +84,33 @@ module Tim
           ti = FactoryGirl.build(:target_image_import, :build_method => "SNAPSHOT")
           ti.should_not_receive(:create_factory_target_image)
           ti.save
+        end
+
+        it "should send base image id to factory if it is set on image version" do
+          image_version = FactoryGirl.build(:image_version_with_full_tree,
+                                            :factory_base_image_id => "1234")
+          target_image = FactoryGirl.build(:target_image,
+                                           :image_version => image_version)
+          target_image.stub(:populate_factory_fields)
+          mock_target_image = double("factory_target_image")
+          Tim::ImageFactory::TargetImage.stub(:new).and_return(mock_target_image)
+          mock_target_image.should_receive(:parameters=)
+          mock_target_image.should_receive(:base_image_id=)
+          mock_target_image.should_receive(:save!)
+          target_image.save
+        end
+
+        it "should send template to factory if factory base image id is not set on image version" do
+          image_version = FactoryGirl.build(:image_version_with_full_tree)
+          target_image = FactoryGirl.build(:target_image,
+                                           :image_version => image_version)
+          target_image.stub(:populate_factory_fields)
+          mock_target_image = double("factory_target_image")
+          Tim::ImageFactory::TargetImage.stub(:new).and_return(mock_target_image)
+          mock_target_image.should_receive(:parameters=)
+          mock_target_image.should_receive(:template=)
+          mock_target_image.should_receive(:save!)
+          target_image.save
         end
       end
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -42,8 +42,9 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
   create_table "tim_image_versions", :force => true do |t|
     t.integer  "base_image_id"
     t.integer  "template_id"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at",            :null => false
+    t.datetime "updated_at",            :null => false
+    t.string   "factory_base_image_id"
   end
 
   create_table "tim_provider_images", :force => true do |t|


### PR DESCRIPTION
Return custom Exception on Factory Connection Refused

Raises a more appropriate exception when Tim can not
connect to ImageFactory.

Fixes: https://github.com/aeolus-incubator/tim/issues/83
