### PR TITLE
Added methods for returning imgfac request data

### DIFF
--- a/app/models/tim/provider_image.rb
+++ b/app/models/tim/provider_image.rb
@@ -23,15 +23,23 @@ module Tim
     end
 
     private
+    def factory_provider_credentials
+      @credentials
+    end
+
+    def factory_provider
+      self.provider
+    end
+
     def create_factory_provider_image
       begin
-        provider_image = ImageFactory::ProviderImage.new(:credentials => @credentials,
+        provider_image = ImageFactory::ProviderImage.new(:credentials => factory_provider_credentials,
                                                           # TODO Remove this when upgrading to 3.2
                                                           # target conflicts with rails 3.0.10
                                                           # ActiveRecord::Associations::Association#target
                                                           :target => target_image.target,
                                                           :parameters => "")
-        provider_image.provider = self.provider
+        provider_image.provider = factory_provider
         # TODO There is a bug in ARes 3.0.10 that will add map name twice when setting in mass assign.  So we set
         # parameters separately.
         # Setting parameters at mass assign results in json => {"target_image":"parameters":{"parameters":{"..."}}}"


### PR DESCRIPTION
Added methods for returning provider account and
provider information.  These methods can then be
easily overridden to generate this data from other
sources such as Conductor ProviderAccount.
