### PR TITLE
Added State Machine to target/provider images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,8 @@ gemspec
 
 # To use debugger
 # gem 'debugger'
+
+# FIXME This should be imported from tim.gemspec by bundler.  This does not
+# seem to be working, potentially due to this issue:
+# https://github.com/carlhuda/bundler/issues/1041
+gem 'state_machine'

--- a/app/models/tim/fsm.rb
+++ b/app/models/tim/fsm.rb
@@ -1,0 +1,49 @@
+module Tim
+  module FSM
+    def self.included base
+      base.state_machine :fsm_create_state, :initial => :new do
+        event :fsm_create_requested do
+          transition :new => :pending
+        end
+
+        event :fsm_create_accepted do
+          transition :pending => :queued
+        end
+
+        event :fsm_create_start do
+          transition :queued => :in_progress
+        end
+
+        event :fsm_create_failed do
+          transition [:pending, :in_progress] => :failed
+        end
+
+        event :fsm_create_completed do
+          transition [:in_progress] => :complete
+        end
+      end
+
+      base.state_machine :fsm_delete_state, :initial => :inactive do
+        event :fsm_delete_requested do
+          transition [:inactive, :failed] => :pending
+        end
+
+        event :fsm_delete_accepted do
+          transition :pending => :queued
+        end
+
+        event :fsm_delete_started do
+          transition :queued => :in_progress
+        end
+
+        event :fsm_delete_completed do
+          transition :in_progress => :complete
+        end
+
+        event :fsm_delete_failed do
+          transition :in_progress => :failed
+        end
+      end
+    end
+  end
+end

--- a/app/models/tim/provider_image.rb
+++ b/app/models/tim/provider_image.rb
@@ -1,5 +1,7 @@
 module Tim
   class ProviderImage < Tim::Base
+    include FSM
+
     belongs_to :target_image, :inverse_of => :provider_images
     belongs_to :provider_account, :class_name => Tim.provider_account_class
 

--- a/app/models/tim/target_image.rb
+++ b/app/models/tim/target_image.rb
@@ -1,5 +1,7 @@
 module Tim
   class TargetImage < Tim::Base
+    include FSM
+
     belongs_to :image_version, :inverse_of => :target_images
     has_many :provider_images, :inverse_of => :target_image
 

--- a/db/migrate/20130211140935_add_fsm_fields_to_provider_image_and_target_image.rb
+++ b/db/migrate/20130211140935_add_fsm_fields_to_provider_image_and_target_image.rb
@@ -1,0 +1,13 @@
+class AddFsmFieldsToProviderImageAndTargetImage < ActiveRecord::Migration
+  def change
+    add_column :tim_target_images, :fsm_create_state, :string
+    add_column :tim_target_images, :fsm_create_state_message, :text
+    add_column :tim_target_images, :fsm_delete_state, :string
+    add_column :tim_target_images, :fsm_delete_state_message, :text
+
+    add_column :tim_provider_images, :fsm_create_state, :string
+    add_column :tim_provider_images, :fsm_create_state_message, :text
+    add_column :tim_provider_images, :fsm_delete_state, :string
+    add_column :tim_provider_images, :fsm_delete_state_message, :text
+  end
+end

--- a/distros/rpm/rubygem-tim.spec
+++ b/distros/rpm/rubygem-tim.spec
@@ -32,6 +32,7 @@ BuildRequires: rubygem(minitest)
 BuildRequires: rubygem(database_cleaner)
 BuildRequires: rubygem(factory_girl_rails) => 4.1.0
 BuildRequires: rubygem(rake)
+BuildRequires: rubygem(state_machine)
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
 
@@ -92,3 +93,5 @@ popd
 %changelog
 * Tue Oct 23 2012 slinaber - 0.1.2-1
 - Initial package
+* Tue Feb 12 2012 mtaylor - 0.1.2-2
+- Added rubygem-state_machine dependency

--- a/lib/tasks/tim_tasks.rake
+++ b/lib/tasks/tim_tasks.rake
@@ -1,3 +1,6 @@
+require 'state_machine'
+require 'tasks/state_machine'
+
 # desc "Explaining what the task does"
 # task :tim do
 #   # Task goes here

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -60,6 +60,10 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
     t.datetime "created_at",                  :null => false
     t.datetime "updated_at",                  :null => false
     t.integer  "provider_account_id"
+    t.string   "fsm_create_state"
+    t.text     "fsm_create_state_message"
+    t.string   "fsm_delete_state"
+    t.text     "fsm_delete_state_message"
   end
 
   create_table "tim_target_images", :force => true do |t|
@@ -69,10 +73,14 @@ ActiveRecord::Schema.define(:version => 20120423123114264114) do
     t.string   "status"
     t.string   "status_detail"
     t.string   "progress"
-    t.datetime "created_at",                                 :null => false
-    t.datetime "updated_at",                                 :null => false
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
     t.integer  "provider_type_id"
-    t.string   "build_method",     :default => "BARE_METAL"
+    t.string   "build_method",             :default => "BARE_METAL"
+    t.string   "fsm_create_state"
+    t.text     "fsm_create_state_message"
+    t.string   "fsm_delete_state"
+    t.text     "fsm_delete_state_message"
   end
 
   create_table "tim_templates", :force => true do |t|

--- a/tim.gemspec
+++ b/tim.gemspec
@@ -22,12 +22,14 @@ Gem::Specification.new do |s|
   s.add_dependency "haml"
   s.add_dependency "nokogiri"
   s.add_dependency "oauth"
+  s.add_dependency "state_machine"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "factory_girl_rails", "~> 4.1.0"
   s.add_development_dependency "minitest"
+  s.add_development_dependency "ruby-graphviz"
 
   #s.add_development_dependency "jquery-rails"
 end


### PR DESCRIPTION
You can generate a jpeg graph of the state machine defined in both the target_image and provider_image class (NOTE they both use the same state machine) from the test/dummy dir using the following rake command:

```
rake state_machine:draw FILE=../../app/models/tim/target_image.rb CLASS=Tim::TargetImage
rake state_machine:draw FILE=../../app/models/tim/provider_image.rb CLASS=Tim::ProviderImage
```
